### PR TITLE
Add WithFields helper, specs

### DIFF
--- a/base.go
+++ b/base.go
@@ -38,6 +38,10 @@ type Logger interface {
 	// Leveled returns a copy of the current logger with a different level.
 	Leveled(level Level) Logger
 
+	// WithFields returns a copy of the current logger with extra provided
+	// fields that will be present in every emitted log message.
+	WithFields(keysAndValues ...any) Logger
+
 	Debug(msg string, keysAndValues ...any)
 	Info(msg string, keysAndValues ...any)
 	Warning(msg string, keysAndValues ...any)

--- a/common.go
+++ b/common.go
@@ -2,15 +2,15 @@ package stdlog
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 )
 
-func ensureKV(ev *stdLoggerEvent) {
-	if l := len(ev.kvs); l != 0 && l%2 != 0 {
-		panic(fmt.Errorf("uneven keys and values passed to %s", ev.Level.String()))
-	}
+type kv struct {
+	k string
+	v any
 }
 
 func caller(skip int) string {
@@ -32,16 +32,21 @@ func stackTrace(skip int) string {
 	var data []string
 	for {
 		frame, more := frames.Next()
-		data = append(data, fmt.Sprintf("%s\n\t%s:%d\n", frame.Function, frame.File, frame.Line))
+		if frame.Function == "" {
+			data = append(data, fmt.Sprintf("%s:%d\n", frame.File, frame.Line))
+		} else {
+			data = append(data, fmt.Sprintf("%s\n\t%s:%d\n", frame.Function, frame.File, frame.Line))
+		}
+
 		if !more {
 			break
 		}
 	}
-	return strings.Join(data, "\n")
+	return strings.Join(data, "")
 }
 
-func ptrCopy[T any](src *T) *T {
-	var res T
-	res = *src
-	return &res
+func stdField(k, v any) *kv {
+	return &kv{fmt.Sprintf("%v", k), v}
 }
+
+var stdExit func(int) = os.Exit

--- a/discard.go
+++ b/discard.go
@@ -23,3 +23,5 @@ func (n noop) Error(err error, msg string, keysAndValues ...any) {}
 func (n noop) Fatal(msg string, keysAndValues ...any) { os.Exit(1) }
 
 func (n noop) FatalError(err error, msg string, keysAndValues ...any) { os.Exit(1) }
+
+func (n noop) WithFields(keysAndValues ...any) Logger { return n }

--- a/event.go
+++ b/event.go
@@ -1,6 +1,7 @@
 package stdlog
 
 import (
+	"slices"
 	"sync"
 	"time"
 )
@@ -11,14 +12,22 @@ type stdLoggerEvent struct {
 	Backtrace string
 	Message   string
 	Error     error
-	kvs       []any
+	kvs       []*kv
 }
 
-func (e *stdLoggerEvent) prepare(lvl Level, message string, kvs []any) *stdLoggerEvent {
+func (e *stdLoggerEvent) prepare(lvl Level, message string, basekvs []*kv, kvs []any) *stdLoggerEvent {
 	e.Level = lvl
 	e.Timestamp = time.Now()
 	e.Message = message
-	e.kvs = kvs
+	newSize := len(basekvs) + (len(kvs) / 2)
+	e.kvs = slices.Grow(e.kvs, newSize)
+	for i := 0; i < len(basekvs); i++ {
+		e.kvs = append(e.kvs, basekvs[i])
+	}
+	for i := 0; i < len(kvs); i += 2 {
+		e.kvs = append(e.kvs, stdField(kvs[i], kvs[i+1]))
+	}
+	e.kvs = e.kvs[:newSize]
 	e.Backtrace = ""
 	e.Error = nil
 	return e

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/go-stdlog/stdlog
 
 go 1.22.5
+
+require github.com/stretchr/testify v1.10.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/std_base.go
+++ b/std_base.go
@@ -1,0 +1,107 @@
+package stdlog
+
+import (
+	"io"
+	"slices"
+)
+
+type stdBase struct {
+	output     io.Writer
+	name       string
+	level      Level
+	baseFields []*kv
+	handler    func(name string, out io.Writer, ev *stdLoggerEvent)
+}
+
+func (s *stdBase) dup() *stdBase {
+	n := &stdBase{
+		output:     s.output,
+		name:       s.name,
+		level:      s.level,
+		baseFields: make([]*kv, 0, len(s.baseFields)),
+		handler:    s.handler,
+	}
+	for _, v := range s.baseFields {
+		n.baseFields = append(n.baseFields, v)
+	}
+	return n
+}
+
+func (s *stdBase) Named(name string) Logger {
+	n := s.dup()
+	if len(s.name) == 0 {
+		n.name = name
+	} else {
+		n.name = s.name + "." + name
+	}
+
+	return n
+}
+
+func (s *stdBase) WithFields(keysAndValues ...any) Logger {
+	if len(keysAndValues)%2 != 0 {
+		panic("uneven number of keys and values")
+	}
+
+	n := s.dup()
+	n.baseFields = slices.Grow(n.baseFields, len(keysAndValues)/2)
+	for i := 0; i < len(keysAndValues); i += 2 {
+		n.baseFields = append(n.baseFields, stdField(keysAndValues[i], keysAndValues[i+1]))
+	}
+
+	return n
+}
+
+func (s *stdBase) SetLevel(level Level) { s.level = level }
+
+func (s *stdBase) Leveled(level Level) Logger {
+	n := s.dup()
+	n.level = level
+	return n
+}
+
+func (s *stdBase) Debug(msg string, kvs ...any) {
+	if s.level != LevelDebug {
+		return
+	}
+	s.handler(s.name, s.output, getEventPool().prepare(LevelDebug, msg, s.baseFields, kvs))
+}
+
+func (s *stdBase) Info(msg string, kvs ...any) {
+	if s.level > LevelInfo {
+		return
+	}
+	s.handler(s.name, s.output, getEventPool().prepare(LevelInfo, msg, s.baseFields, kvs))
+}
+
+func (s *stdBase) Warning(msg string, kvs ...any) {
+	if s.level > LevelWarning {
+		return
+	}
+	s.handler(s.name, s.output, getEventPool().prepare(LevelWarning, msg, s.baseFields, kvs))
+}
+
+func (s *stdBase) Error(err error, msg string, kvs ...any) {
+	if s.level > LevelError {
+		return
+	}
+	ev := getEventPool().prepare(LevelError, msg, s.baseFields, kvs)
+	ev.Error = err
+	ev.Backtrace = stackTrace(3)
+	s.handler(s.name, s.output, ev)
+}
+
+func (s *stdBase) Fatal(msg string, kvs ...any) {
+	ev := getEventPool().prepare(LevelFatal, msg, s.baseFields, kvs)
+	ev.Backtrace = stackTrace(3)
+	s.handler(s.name, s.output, ev)
+	stdExit(1)
+}
+
+func (s *stdBase) FatalError(err error, msg string, kvs ...any) {
+	ev := getEventPool().prepare(LevelFatal, msg, s.baseFields, kvs)
+	ev.Error = err
+	ev.Backtrace = stackTrace(3)
+	s.handler(s.name, s.output, ev)
+	stdExit(1)
+}

--- a/std_json.go
+++ b/std_json.go
@@ -2,124 +2,48 @@ package stdlog
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
-	"os"
 	"time"
 )
 
-type stdLoggerJSON struct {
-	output io.Writer
-	name   string
-	level  Level
-}
-
 func NewStdJSON(writer io.Writer) Logger {
-	return &stdLoggerJSON{output: writer}
-}
-
-func (s *stdLoggerJSON) Named(name string) Logger {
-	n := new(stdLoggerJSON)
-	if len(s.name) == 0 {
-		n.name = name
-	} else {
-		n.name = s.name + "." + name
+	b := &stdBase{
+		output: writer,
 	}
-	n.level = s.level
-	n.output = s.output
+	b.handler = func(name string, out io.Writer, ev *stdLoggerEvent) {
+		defer putEventPool(ev)
+		callerLocation := caller(2)
+		data := map[string]any{
+			"time":  ev.Timestamp.UTC().Format(time.RFC3339Nano),
+			"level": ev.Level.String(),
+		}
+		if len(name) > 0 {
+			data["name"] = name
+		}
+		data["caller"] = callerLocation
+		data["msg"] = ev.Message
+		if ev.Error != nil {
+			data["error"] = ev.Error.Error()
+		}
+		if len(ev.kvs) > 0 {
+			mp := make(map[string]any, len(ev.kvs))
+			for _, kv := range ev.kvs {
+				mp[kv.k] = kv.v
+			}
+			data["extra"] = mp
+		}
 
-	return n
-}
+		if len(ev.Backtrace) > 0 {
+			data["backtrace"] = ev.Backtrace
+		}
+		logMsg, err := json.Marshal(data)
+		if err != nil {
+			b.Error(err, "Failed writing log entry")
+			return
+		}
 
-func (s *stdLoggerJSON) SetLevel(level Level) { s.level = level }
-
-func (s *stdLoggerJSON) Leveled(level Level) Logger {
-	cp := ptrCopy(s)
-	cp.level = level
-	return cp
-}
-
-func (s *stdLoggerJSON) Debug(msg string, kvs ...any) {
-	if s.level != LevelDebug {
-		return
+		_, _ = out.Write(logMsg)
+		_, _ = out.Write([]byte{'\n'})
 	}
-	s.do(getEventPool().prepare(LevelDebug, msg, kvs))
-}
-
-func (s *stdLoggerJSON) Info(msg string, kvs ...any) {
-	if s.level >= LevelInfo {
-		return
-	}
-	s.do(getEventPool().prepare(LevelInfo, msg, kvs))
-}
-
-func (s *stdLoggerJSON) Warning(msg string, kvs ...any) {
-	if s.level >= LevelWarning {
-		return
-	}
-	s.do(getEventPool().prepare(LevelWarning, msg, kvs))
-}
-
-func (s *stdLoggerJSON) Error(err error, msg string, kvs ...any) {
-	if s.level >= LevelError {
-		return
-	}
-	ev := getEventPool().prepare(LevelError, msg, kvs)
-	ev.Error = err
-	ev.Backtrace = stackTrace(1)
-	s.do(ev)
-}
-
-func (s *stdLoggerJSON) Fatal(msg string, kvs ...any) {
-	ev := getEventPool().prepare(LevelFatal, msg, kvs)
-	ev.Backtrace = stackTrace(1)
-	s.do(ev)
-	os.Exit(1)
-}
-
-func (s *stdLoggerJSON) FatalError(err error, msg string, kvs ...any) {
-	ev := getEventPool().prepare(LevelFatal, msg, kvs)
-	ev.Error = err
-	ev.Backtrace = stackTrace(1)
-	s.do(ev)
-	os.Exit(1)
-}
-
-func (s *stdLoggerJSON) do(ev *stdLoggerEvent) {
-	defer putEventPool(ev)
-	ensureKV(ev)
-	callerLocation := caller(2)
-	data := map[string]any{
-		"time":  ev.Timestamp.UTC().Format(time.RFC3339Nano),
-		"level": ev.Level.String(),
-	}
-	if len(s.name) > 0 {
-		data["name"] = s.name
-	}
-	data["caller"] = callerLocation
-	data["msg"] = ev.Message
-	if ev.Error != nil {
-		data["error"] = ev.Error.Error()
-	}
-	data["extra"] = stdJSONKVs(ev)
-	if len(ev.Backtrace) > 0 {
-		data["backtrace"] = ev.Backtrace
-	}
-	out, err := json.Marshal(data)
-	if err != nil {
-		s.Error(err, "Failed writing log entry")
-		return
-	}
-
-	_, _ = s.output.Write([]byte(string(out) + "\n"))
-}
-
-func stdJSONKVs(ev *stdLoggerEvent) any {
-	mp := map[string]any{}
-
-	for i := 0; i < len(ev.kvs); i += 2 {
-		mp[fmt.Sprintf("%v", ev.kvs[i])] = ev.kvs[i+1]
-	}
-
-	return mp
+	return b
 }

--- a/std_json_test.go
+++ b/std_json_test.go
@@ -1,0 +1,162 @@
+package stdlog
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestStdJSON(t *testing.T) {
+	stdExitCh := make(chan int, 100)
+	stdExit = func(code int) {
+		stdExitCh <- code
+	}
+	drainStdExit := func() {
+		for {
+			select {
+			case <-stdExitCh:
+			default:
+				return
+			}
+		}
+	}
+
+	makeLogger := func() (Logger, *bytes.Buffer) {
+		buf := new(bytes.Buffer)
+		l := NewStdJSON(buf)
+		return l, buf
+	}
+
+	decode := func(t *testing.T, buf *bytes.Buffer) map[string]any {
+		t.Helper()
+		v := make(map[string]any)
+		err := json.Unmarshal(buf.Bytes(), &v)
+		require.NoError(t, err)
+		return v
+	}
+
+	t.Run("Named", func(t *testing.T) {
+		t.Run("Single", func(t *testing.T) {
+			drainStdExit()
+			l, out := makeLogger()
+			l = l.Named("a")
+			l.Info("Hello, World!")
+			d := decode(t, out)["name"]
+			assert.Equal(t, "a", d)
+
+		})
+		t.Run("Multiple", func(t *testing.T) {
+			drainStdExit()
+			l, out := makeLogger()
+			l = l.Named("a").Named("b")
+			l.Info("Hello, World!")
+			d := decode(t, out)["name"]
+			assert.Equal(t, "a.b", d)
+		})
+	})
+	t.Run("WithFields", func(t *testing.T) {
+		drainStdExit()
+		l, out := makeLogger()
+		l = l.Named("a").Named("b").WithFields("foo", "bar")
+		l.Info("Hello, World!")
+		d := decode(t, out)["extra"].(map[string]any)["foo"]
+		assert.Equal(t, "bar", d)
+	})
+	t.Run("Leveled", func(t *testing.T) {
+		drainStdExit()
+		l, out := makeLogger()
+		l = l.Named("a").Named("b").WithFields("foo", "bar").Leveled(LevelInfo)
+		l.Debug("DO NOT APPEAR")
+		l.Info("Hello, World!")
+		dec := decode(t, out)
+		assert.Equal(t, "Hello, World!", dec["msg"])
+		assert.Equal(t, "INFO", dec["level"])
+	})
+	t.Run("SetLevel", func(t *testing.T) {
+		drainStdExit()
+		l, out := makeLogger()
+		l = l.Named("a").Named("b").WithFields("foo", "bar")
+		l.SetLevel(LevelInfo)
+		l.Debug("DO NOT APPEAR")
+		l.Info("Hello, World!")
+		dec := decode(t, out)
+		assert.Equal(t, "Hello, World!", dec["msg"])
+		assert.Equal(t, "INFO", dec["level"])
+	})
+
+	t.Run("Debug", func(t *testing.T) {
+		drainStdExit()
+		l, out := makeLogger()
+		l = l.Named("a").Named("b").WithFields("foo", "bar")
+		l.Debug("Hello, World!")
+		dec := decode(t, out)
+		assert.Equal(t, "Hello, World!", dec["msg"])
+		assert.Equal(t, "DEBUG", dec["level"])
+	})
+	t.Run("Info", func(t *testing.T) {
+		drainStdExit()
+		l, out := makeLogger()
+		l = l.Named("a").Named("b").WithFields("foo", "bar")
+		l.Info("Hello, World!")
+		dec := decode(t, out)
+		assert.Equal(t, "Hello, World!", dec["msg"])
+		assert.Equal(t, "INFO", dec["level"])
+	})
+	t.Run("Warning", func(t *testing.T) {
+		drainStdExit()
+		l, out := makeLogger()
+		l = l.Named("a").Named("b").WithFields("foo", "bar")
+		l.Warning("Hello, World!")
+		dec := decode(t, out)
+		assert.Equal(t, "Hello, World!", dec["msg"])
+		assert.Equal(t, "WARN", dec["level"])
+	})
+	t.Run("Error", func(t *testing.T) {
+		drainStdExit()
+		l, out := makeLogger()
+		l = l.Named("a").Named("b").WithFields("foo", "bar")
+		err := fmt.Errorf("error")
+		l.Error(err, "Hello, World!")
+		dec := decode(t, out)
+		assert.Equal(t, "Hello, World!", dec["msg"])
+		assert.Equal(t, "ERROR", dec["level"])
+		assert.NotNil(t, dec["backtrace"])
+		assert.Equal(t, "error", dec["error"])
+	})
+	t.Run("Error, nil error", func(t *testing.T) {
+		drainStdExit()
+		l, out := makeLogger()
+		l = l.Named("a").Named("b").WithFields("foo", "bar")
+		l.Error(nil, "Hello, World!")
+		dec := decode(t, out)
+		assert.Equal(t, "Hello, World!", dec["msg"])
+		assert.Equal(t, "ERROR", dec["level"])
+		assert.NotNil(t, dec["backtrace"])
+		assert.Nil(t, dec["error"])
+	})
+	t.Run("Fatal", func(t *testing.T) {
+		drainStdExit()
+		l, out := makeLogger()
+		l = l.Named("a").Named("b").WithFields("foo", "bar")
+		l.Fatal("Hello, World!")
+		dec := decode(t, out)
+		assert.Equal(t, "Hello, World!", dec["msg"])
+		assert.Equal(t, "FATAL", dec["level"])
+		assert.NotEmpty(t, stdExitCh)
+	})
+	t.Run("FatalError", func(t *testing.T) {
+		drainStdExit()
+		l, out := makeLogger()
+		l = l.Named("a").Named("b").WithFields("foo", "bar")
+		err := fmt.Errorf("error")
+		l.FatalError(err, "Hello, World!")
+		dec := decode(t, out)
+		assert.Equal(t, "Hello, World!", dec["msg"])
+		assert.Equal(t, "FATAL", dec["level"])
+		assert.NotNil(t, dec["backtrace"])
+		assert.Equal(t, "error", dec["error"])
+	})
+}

--- a/std_text.go
+++ b/std_text.go
@@ -3,130 +3,60 @@ package stdlog
 import (
 	"fmt"
 	"io"
-	"os"
 	"slices"
 	"strings"
 )
 
-type stdLoggerText struct {
-	output io.Writer
-	name   string
-	level  Level
-}
-
 var timeFormat = "2006-01-02 15:04:05.000000-07:00"
 
 func NewStd(writer io.Writer) Logger {
-	return &stdLoggerText{output: writer}
-}
-
-func (s *stdLoggerText) Named(name string) Logger {
-	n := new(stdLoggerText)
-	if len(s.name) == 0 {
-		n.name = name
-	} else {
-		n.name = s.name + "." + name
-	}
-	n.level = s.level
-	n.output = s.output
-
-	return n
-}
-
-func (s *stdLoggerText) SetLevel(level Level) { s.level = level }
-
-func (s *stdLoggerText) Leveled(level Level) Logger {
-	cp := ptrCopy(s)
-	cp.level = level
-	return cp
-}
-
-func (s *stdLoggerText) Debug(msg string, kvs ...any) {
-	if s.level != LevelDebug {
-		return
-	}
-	s.do(getEventPool().prepare(LevelDebug, msg, kvs))
-}
-
-func (s *stdLoggerText) Info(msg string, kvs ...any) {
-	if s.level >= LevelInfo {
-		return
-	}
-	s.do(getEventPool().prepare(LevelInfo, msg, kvs))
-}
-
-func (s *stdLoggerText) Warning(msg string, kvs ...any) {
-	if s.level >= LevelWarning {
-		return
-	}
-	s.do(getEventPool().prepare(LevelWarning, msg, kvs))
-}
-
-func (s *stdLoggerText) Error(err error, msg string, kvs ...any) {
-	if s.level >= LevelError {
-		return
-	}
-	ev := getEventPool().prepare(LevelError, msg, kvs)
-	ev.Error = err
-	ev.Backtrace = stackTrace(3)
-	s.do(ev)
-}
-
-func (s *stdLoggerText) Fatal(msg string, kvs ...any) {
-	ev := getEventPool().prepare(LevelFatal, msg, kvs)
-	ev.Backtrace = stackTrace(3)
-	s.do(ev)
-	os.Exit(1)
-}
-
-func (s *stdLoggerText) FatalError(err error, msg string, kvs ...any) {
-	ev := getEventPool().prepare(LevelFatal, msg, kvs)
-	ev.Error = err
-	ev.Backtrace = stackTrace(3)
-	s.do(ev)
-	os.Exit(1)
-}
-
-func (s *stdLoggerText) do(ev *stdLoggerEvent) {
-	defer putEventPool(ev)
-	ensureKV(ev)
-	callerLocation := caller(3)
-	comps := []string{
-		ev.Timestamp.Format(timeFormat),
-		"[" + ev.Level.String() + "]",
-		s.name,
-		callerLocation,
-		ev.Message,
-		formatKeysValsStd(ev),
-	}
-	comps = slices.DeleteFunc(comps, func(s string) bool { return len(s) == 0 })
-	_, _ = fmt.Fprintf(s.output, "%s\n", strings.Join(comps, " "))
-	if ev.Backtrace != "" {
-		lines := strings.Split(ev.Backtrace, "\n")
-		for i, line := range lines {
-			lines[i] = "\t" + line
-		}
-		_, _ = fmt.Fprintf(s.output, "%s\n", strings.Join(lines, "\n"))
+	return &stdBase{
+		output: writer,
+		handler: func(name string, out io.Writer, ev *stdLoggerEvent) {
+			defer putEventPool(ev)
+			callerLocation := caller(3)
+			comps := []string{
+				ev.Timestamp.Format(timeFormat),
+				"[" + ev.Level.String() + "]",
+				name,
+				callerLocation,
+				ev.Message,
+				formatKeysValsStd(ev),
+			}
+			comps = slices.DeleteFunc(comps, func(s string) bool { return len(s) == 0 })
+			_, _ = fmt.Fprintf(out, "%s\n", strings.Join(comps, " "))
+			if ev.Backtrace != "" {
+				lines := strings.Split(ev.Backtrace, "\n")
+				for i, line := range lines {
+					lines[i] = "\t" + line
+				}
+				_, _ = fmt.Fprintf(out, "%s\n", strings.Join(lines, "\n"))
+			}
+		},
 	}
 }
 
 func formatKeysValsStd(ev *stdLoggerEvent) string {
-	size := len(ev.kvs) / 2
+	size := len(ev.kvs)
 	if ev.Error != nil {
 		size++
 	}
+
 	res := make([]string, size)
-	idx := 0
-	for i := 0; i < len(ev.kvs)-1; i += 2 {
-		if s, ok := ev.kvs[i+1].(string); ok {
-			res[idx] = fmt.Sprintf("%v=%q", ev.kvs[i], s)
-		} else {
-			res[idx] = fmt.Sprintf("%v=%v", ev.kvs[i], ev.kvs[i+1])
+	for i, kv := range ev.kvs {
+		switch t := kv.v.(type) {
+		case string:
+			res[i] = fmt.Sprintf("%s=%q", kv.k, t)
+		case fmt.Stringer:
+			res[i] = fmt.Sprintf("%s=%s", kv.k, t.String())
+		default:
+			res[i] = fmt.Sprintf("%s=%v", kv.k, kv.v)
 		}
-		idx++
 	}
+
 	if ev.Error != nil {
-		res[idx] = fmt.Sprintf("error=%q", ev.Error.Error())
+		res[len(ev.kvs)] = fmt.Sprintf("error=%q", ev.Error.Error())
 	}
+
 	return strings.Join(res, " ")
 }

--- a/std_text_test.go
+++ b/std_text_test.go
@@ -1,0 +1,173 @@
+package stdlog
+
+import (
+	"bytes"
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"regexp"
+	"testing"
+)
+
+func TestStdText(t *testing.T) {
+	stdExitCh := make(chan int, 100)
+	stdExit = func(code int) {
+		stdExitCh <- code
+	}
+	drainStdExit := func() {
+		for {
+			select {
+			case <-stdExitCh:
+			default:
+				return
+			}
+		}
+	}
+
+	makeLogger := func() (Logger, *bytes.Buffer) {
+		buf := new(bytes.Buffer)
+		l := NewStd(buf)
+		return l, buf
+	}
+
+	messageRegexp := regexp.MustCompile(`^\d{4}-\d{2}-\d{2}\s\d+:\d+:\d+.\d+(?:-\d+:\d+)?\s\[([^]]+)]\s(?:(\S+)\s)?[^:]+:\d+\s([^$]+)\n$`)
+	assertMessage := func(t *testing.T, buf *bytes.Buffer, msg string) {
+		t.Helper()
+		require.Truef(t, messageRegexp.MatchString(buf.String()), "expected %q to match %s", buf.String(), messageRegexp.String())
+
+		groups := messageRegexp.FindStringSubmatch(buf.String())
+		if len(groups) != 4 {
+			return
+		}
+		assert.Equal(t, msg, groups[3])
+	}
+	assertName := func(t *testing.T, buf *bytes.Buffer, name string) {
+		t.Helper()
+		require.Truef(t, messageRegexp.MatchString(buf.String()), "expected %q to match %s", buf.String(), messageRegexp.String())
+
+		groups := messageRegexp.FindStringSubmatch(buf.String())
+		if len(groups) != 4 {
+			return
+		}
+		assert.Equal(t, name, groups[2])
+	}
+	assertLevel := func(t *testing.T, buf *bytes.Buffer, level string) {
+		t.Helper()
+		require.Truef(t, messageRegexp.MatchString(buf.String()), "expected %q to match %s", buf.String(), messageRegexp.String())
+
+		groups := messageRegexp.FindStringSubmatch(buf.String())
+		if len(groups) != 4 {
+			return
+		}
+		assert.Equal(t, level, groups[1])
+	}
+	assertPattern := func(t *testing.T, buf *bytes.Buffer, pattern string) {
+		t.Helper()
+		require.Truef(t, regexp.MustCompile(pattern).MatchString(buf.String()), "expected %q to match %s", buf.String(), pattern)
+	}
+
+	t.Run("Named", func(t *testing.T) {
+		t.Run("Single", func(t *testing.T) {
+			drainStdExit()
+			l, out := makeLogger()
+			l = l.Named("a")
+			l.Info("Hello, World!")
+			assertMessage(t, out, "Hello, World!")
+			assertName(t, out, "a")
+
+		})
+		t.Run("Multiple", func(t *testing.T) {
+			drainStdExit()
+			l, out := makeLogger()
+			l = l.Named("a").Named("b")
+			l.Info("Hello, World!")
+			assertMessage(t, out, "Hello, World!")
+			assertName(t, out, "a.b")
+		})
+	})
+	t.Run("WithFields", func(t *testing.T) {
+		drainStdExit()
+		l, out := makeLogger()
+		l = l.Named("a").Named("b").WithFields("foo", "bar")
+		l.Info("Hello, World!")
+		assertMessage(t, out, "Hello, World! foo=\"bar\"")
+	})
+	t.Run("Leveled", func(t *testing.T) {
+		drainStdExit()
+		l, out := makeLogger()
+		l = l.Named("a").Named("b").WithFields("foo", "bar").Leveled(LevelInfo)
+		l.Debug("DO NOT APPEAR")
+		l.Info("Hello, World!")
+		assertMessage(t, out, "Hello, World! foo=\"bar\"")
+	})
+	t.Run("SetLevel", func(t *testing.T) {
+		drainStdExit()
+		l, out := makeLogger()
+		l = l.Named("a").Named("b").WithFields("foo", "bar")
+		l.SetLevel(LevelInfo)
+		l.Debug("DO NOT APPEAR")
+		l.Info("Hello, World!")
+		assertMessage(t, out, "Hello, World! foo=\"bar\"")
+	})
+
+	t.Run("Debug", func(t *testing.T) {
+		drainStdExit()
+		l, out := makeLogger()
+		l = l.Named("a").Named("b").WithFields("foo", "bar")
+		l.SetLevel(LevelDebug)
+		l.Debug("Hello, World!")
+		assertMessage(t, out, "Hello, World! foo=\"bar\"")
+		assertLevel(t, out, "DEBUG")
+	})
+	t.Run("Info", func(t *testing.T) {
+		drainStdExit()
+		l, out := makeLogger()
+		l = l.Named("a").Named("b").WithFields("foo", "bar")
+		l.Info("Hello, World!")
+		assertMessage(t, out, "Hello, World! foo=\"bar\"")
+		assertLevel(t, out, "INFO")
+	})
+	t.Run("Warning", func(t *testing.T) {
+		drainStdExit()
+		l, out := makeLogger()
+		l = l.Named("a").Named("b").WithFields("foo", "bar")
+		l.Warning("Hello, World!")
+		assertMessage(t, out, "Hello, World! foo=\"bar\"")
+		assertLevel(t, out, "WARN")
+	})
+	t.Run("Error", func(t *testing.T) {
+		drainStdExit()
+		l, out := makeLogger()
+		l = l.Named("a").Named("b").WithFields("foo", "bar")
+		err := errors.New("error")
+		l.Error(err, "Hello, World!")
+		assertPattern(t, out, `Hello, World! foo="bar" error="error"\n(\t[a-zA-Z\.0-9/-]+\n\t{2}[/a-zA-Z0-9_.]+(?::\d+)?\n?)*`)
+		assertLevel(t, out, "ERROR")
+	})
+	t.Run("Error, nil error", func(t *testing.T) {
+		drainStdExit()
+		l, out := makeLogger()
+		l = l.Named("a").Named("b").WithFields("foo", "bar")
+		l.Error(nil, "Hello, World!")
+		assertPattern(t, out, `Hello, World! foo="bar"\n(\t[a-zA-Z\.0-9/-]+\n\t{2}[/a-zA-Z0-9_.]+(?::\d+)?\n?)*`)
+		assertLevel(t, out, "ERROR")
+	})
+	t.Run("Fatal", func(t *testing.T) {
+		drainStdExit()
+		l, out := makeLogger()
+		l = l.Named("a").Named("b").WithFields("foo", "bar")
+		l.Fatal("Hello, World!")
+		assertPattern(t, out, `Hello, World! foo="bar"\n(\t[a-zA-Z\.0-9/-]+\n\t{2}[/a-zA-Z0-9_.]+(?::\d+)?\n?)*`)
+		assertLevel(t, out, "FATAL")
+		assert.NotEmpty(t, stdExitCh)
+	})
+	t.Run("FatalError", func(t *testing.T) {
+		drainStdExit()
+		l, out := makeLogger()
+		l = l.Named("a").Named("b").WithFields("foo", "bar")
+		err := errors.New("error")
+		l.FatalError(err, "Hello, World!")
+		assertPattern(t, out, `Hello, World! foo="bar" error="error"\n(\t[a-zA-Z\.0-9/-]+\n\t{2}[/a-zA-Z0-9_.]+(?::\d+)?\n?)*`)
+		assertLevel(t, out, "FATAL")
+	})
+}


### PR DESCRIPTION
This PR adds an `WithFields` helper to the `Logger` interface, fixes a bug with `Level` filtering, which excluded the configured level, and adds specs for `StdText` and `StdJSON`