### PR TITLE
feat: Implement Logger.Skipping

### DIFF
--- a/base.go
+++ b/base.go
@@ -42,6 +42,10 @@ type Logger interface {
 	// fields that will be present in every emitted log message.
 	WithFields(keysAndValues ...any) Logger
 
+	// Skipping returns a copy of the current logger that will skip a given
+	// number of call stacks.
+	Skipping(count uint) Logger
+
 	Debug(msg string, keysAndValues ...any)
 	Info(msg string, keysAndValues ...any)
 	Warning(msg string, keysAndValues ...any)

--- a/discard.go
+++ b/discard.go
@@ -12,6 +12,8 @@ func (n noop) SetLevel(level Level) {}
 
 func (n noop) Leveled(level Level) Logger { return n }
 
+func (n noop) Skipping(count uint) Logger { return n }
+
 func (n noop) Debug(msg string, keysAndValues ...any) {}
 
 func (n noop) Info(msg string, keysAndValues ...any) {}

--- a/event.go
+++ b/event.go
@@ -7,6 +7,7 @@ import (
 
 type stdLoggerEvent struct {
 	Level     Level
+	StackSkip uint
 	Timestamp time.Time
 	Backtrace string
 	Message   string
@@ -14,10 +15,11 @@ type stdLoggerEvent struct {
 	kvs       []*kv
 }
 
-func (e *stdLoggerEvent) prepare(lvl Level, message string, basekvs []*kv, kvs []any) *stdLoggerEvent {
+func (e *stdLoggerEvent) prepare(lvl Level, message string, basekvs []*kv, kvs []any, stackSkip uint) *stdLoggerEvent {
 	e.Level = lvl
 	e.Timestamp = time.Now()
 	e.Message = message
+	e.StackSkip = stackSkip
 	newSize := len(basekvs) + (len(kvs) / 2)
 	e.kvs = make([]*kv, 0, newSize)
 	for i := 0; i < len(basekvs); i++ {

--- a/std_base.go
+++ b/std_base.go
@@ -11,6 +11,7 @@ type stdBase struct {
 	level      Level
 	baseFields []*kv
 	handler    func(name string, out io.Writer, ev *stdLoggerEvent)
+	stackSkip  uint
 }
 
 func (s *stdBase) dup() *stdBase {
@@ -20,6 +21,7 @@ func (s *stdBase) dup() *stdBase {
 		level:      s.level,
 		baseFields: make([]*kv, 0, len(s.baseFields)),
 		handler:    s.handler,
+		stackSkip:  s.stackSkip,
 	}
 	for _, v := range s.baseFields {
 		n.baseFields = append(n.baseFields, v)
@@ -34,6 +36,13 @@ func (s *stdBase) Named(name string) Logger {
 	} else {
 		n.name = s.name + "." + name
 	}
+
+	return n
+}
+
+func (s *stdBase) Skipping(level uint) Logger {
+	n := s.dup()
+	n.stackSkip = level
 
 	return n
 }
@@ -64,42 +73,42 @@ func (s *stdBase) Debug(msg string, kvs ...any) {
 	if s.level != LevelDebug {
 		return
 	}
-	s.handler(s.name, s.output, getEventPool().prepare(LevelDebug, msg, s.baseFields, kvs))
+	s.handler(s.name, s.output, getEventPool().prepare(LevelDebug, msg, s.baseFields, kvs, s.stackSkip))
 }
 
 func (s *stdBase) Info(msg string, kvs ...any) {
 	if s.level > LevelInfo {
 		return
 	}
-	s.handler(s.name, s.output, getEventPool().prepare(LevelInfo, msg, s.baseFields, kvs))
+	s.handler(s.name, s.output, getEventPool().prepare(LevelInfo, msg, s.baseFields, kvs, s.stackSkip))
 }
 
 func (s *stdBase) Warning(msg string, kvs ...any) {
 	if s.level > LevelWarning {
 		return
 	}
-	s.handler(s.name, s.output, getEventPool().prepare(LevelWarning, msg, s.baseFields, kvs))
+	s.handler(s.name, s.output, getEventPool().prepare(LevelWarning, msg, s.baseFields, kvs, s.stackSkip))
 }
 
 func (s *stdBase) Error(err error, msg string, kvs ...any) {
 	if s.level > LevelError {
 		return
 	}
-	ev := getEventPool().prepare(LevelError, msg, s.baseFields, kvs)
+	ev := getEventPool().prepare(LevelError, msg, s.baseFields, kvs, s.stackSkip)
 	ev.Error = err
 	ev.Backtrace = stackTrace(3)
 	s.handler(s.name, s.output, ev)
 }
 
 func (s *stdBase) Fatal(msg string, kvs ...any) {
-	ev := getEventPool().prepare(LevelFatal, msg, s.baseFields, kvs)
+	ev := getEventPool().prepare(LevelFatal, msg, s.baseFields, kvs, s.stackSkip)
 	ev.Backtrace = stackTrace(3)
 	s.handler(s.name, s.output, ev)
 	stdExit(1)
 }
 
 func (s *stdBase) FatalError(err error, msg string, kvs ...any) {
-	ev := getEventPool().prepare(LevelFatal, msg, s.baseFields, kvs)
+	ev := getEventPool().prepare(LevelFatal, msg, s.baseFields, kvs, s.stackSkip)
 	ev.Error = err
 	ev.Backtrace = stackTrace(3)
 	s.handler(s.name, s.output, ev)

--- a/std_json.go
+++ b/std_json.go
@@ -28,7 +28,7 @@ func NewStdJSON(writer io.Writer) Logger {
 	}
 	b.handler = func(name string, out io.Writer, ev *stdLoggerEvent) {
 		defer putEventPool(ev)
-		callerLocation := caller(3)
+		callerLocation := caller(3 + int(ev.StackSkip))
 		size := 4
 		if len(name) > 0 {
 			size++

--- a/std_json_test.go
+++ b/std_json_test.go
@@ -159,4 +159,13 @@ func TestStdJSON(t *testing.T) {
 		assert.NotNil(t, dec["backtrace"])
 		assert.Equal(t, "error", dec["error"])
 	})
+	t.Run("Skipping", func(t *testing.T) {
+		drainStdExit()
+		l, out := makeLogger()
+		l = l.Skipping(1).Named("a").Named("b").WithFields("foo", "bar")
+		l.Info("Hello, World!")
+		dec := decode(t, out)
+		assert.Equal(t, "Hello, World!", dec["msg"])
+		assert.Equal(t, "INFO", dec["level"])
+	})
 }

--- a/std_text.go
+++ b/std_text.go
@@ -14,7 +14,7 @@ func NewStd(writer io.Writer) Logger {
 		output: writer,
 		handler: func(name string, out io.Writer, ev *stdLoggerEvent) {
 			defer putEventPool(ev)
-			callerLocation := caller(3)
+			callerLocation := caller(3 + int(ev.StackSkip))
 			comps := []string{
 				ev.Timestamp.Format(timeFormat),
 				"[" + ev.Level.String() + "]",

--- a/std_text_test.go
+++ b/std_text_test.go
@@ -170,4 +170,12 @@ func TestStdText(t *testing.T) {
 		assertPattern(t, out, `Hello, World! foo="bar" error="error"\n(\t[a-zA-Z\.0-9/-]+\n\t{2}[/a-zA-Z0-9_.]+(?::\d+)?\n?)*`)
 		assertLevel(t, out, "FATAL")
 	})
+	t.Run("Skipping", func(t *testing.T) {
+		drainStdExit()
+		l, out := makeLogger()
+		l = l.Skipping(1).Named("a").Named("b").WithFields("foo", "bar")
+		l.Info("Hello, World!")
+		assertPattern(t, out, `Hello, World! foo="bar"\n(\t[a-zA-Z\.0-9/-]+\n\t{2}[/a-zA-Z0-9_.]+(?::\d+)?\n?)*`)
+		assertLevel(t, out, "INFO")
+	})
 }


### PR DESCRIPTION
This pull request introduces a new feature to the logging system: the ability to skip a specified number of call stacks when generating log messages. The changes include updates to the `Logger` interface, implementations for both standard and no-op loggers, modifications to event handling, and corresponding unit tests for the new functionality.

### New Feature: Call Stack Skipping

* **Logger Interface Update**: Added a new method `Skipping(count uint) Logger` to the `Logger` interface, allowing users to specify the number of call stacks to skip in log messages. (`base.go`, [base.goR45-R48](diffhunk://#diff-70f1ecb7be66d191151d77019a75ef0ba0404acdcbaf1aa630099ed46d208771R45-R48))
* **No-op Logger Implementation**: Implemented the `Skipping` method for the no-op logger, ensuring it returns the same no-op instance without altering behavior. (`discard.go`, [discard.goR15-R16](diffhunk://#diff-53e31a6178d7a37af8099cc1a73643f575e060d153b3199ca0984b9c7e17711dR15-R16))

### Event Handling Enhancements

* **Event Structure Update**: Added a new `StackSkip` field to the `stdLoggerEvent` struct to track the number of call stacks to skip. Updated the `prepare` method to accept and set this new field. (`event.go`, [event.goR10-R22](diffhunk://#diff-ebc5808085c4784a2adab4890ba806d0c695f71e0c5507f7c267659ee6c5f2e0R10-R22))
* **Base Logger Modifications**: Added a `stackSkip` field to the `stdBase` struct and ensured it is duplicated when creating new instances. Implemented the `Skipping` method for the standard logger to set the `stackSkip` value. Updated all logging methods to pass the `stackSkip` value to the event preparation process. (`std_base.go`, [[1]](diffhunk://#diff-c722bb4e0414079600b78a20f507dddce3d36ffc6b104eb81732ea2d96803174R14) [[2]](diffhunk://#diff-c722bb4e0414079600b78a20f507dddce3d36ffc6b104eb81732ea2d96803174R24) [[3]](diffhunk://#diff-c722bb4e0414079600b78a20f507dddce3d36ffc6b104eb81732ea2d96803174R43-R49) [[4]](diffhunk://#diff-c722bb4e0414079600b78a20f507dddce3d36ffc6b104eb81732ea2d96803174L67-R111)

### Integration with JSON and Text Loggers

* **JSON Logger Update**: Modified the `NewStdJSON` function to adjust the caller location based on the `StackSkip` value in the event. (`std_json.go`, [std_json.goL31-R31](diffhunk://#diff-10e03c5e23d501477c59b348f4a110f93abcb0e0160ba3d0d8f420da8a1d7b79L31-R31))
* **Text Logger Update**: Updated the `NewStd` function to include the `StackSkip` value when determining the caller location. (`std_text.go`, [std_text.goL17-R17](diffhunk://#diff-6420e0a55e467da2506cca3e1f57fc97eb74694f082cca12806ef88fa496afc6L17-R17))

### Unit Tests for Skipping Feature

* **JSON Logger Tests**: Added a test case to verify the behavior of the `Skipping` method in the JSON logger, ensuring correct log message generation with skipped call stacks. (`std_json_test.go`, [std_json_test.goR162-R170](diffhunk://#diff-f5d79b2ab1477d27bcf753216cbecd97e23a03430cbfb53272478a46d091747dR162-R170))
* **Text Logger Tests**: Added a test case for the `Skipping` method in the text logger, validating the correct formatting and content of log messages with skipped call stacks. (`std_text_test.go`, [std_text_test.goR173-R180](diffhunk://#diff-14f4cd9ed71e02967a0b82b44d7f0fb512ac044c48810741c0fd46a35131f244R173-R180))