### PR TITLE
Chore: Improve error message for uneven key-value pairs

### DIFF
--- a/discard.go
+++ b/discard.go
@@ -14,16 +14,33 @@ func (n noop) Leveled(level Level) Logger { return n }
 
 func (n noop) Skipping(count uint) Logger { return n }
 
-func (n noop) Debug(msg string, keysAndValues ...any) {}
+func (n noop) Debug(msg string, keysAndValues ...any) {
+	assertKvs(LevelDebug.String(), keysAndValues...)
+}
 
-func (n noop) Info(msg string, keysAndValues ...any) {}
+func (n noop) Info(msg string, keysAndValues ...any) {
+	assertKvs(LevelInfo.String(), keysAndValues...)
+}
 
-func (n noop) Warning(msg string, keysAndValues ...any) {}
+func (n noop) Warning(msg string, keysAndValues ...any) {
+	assertKvs(LevelWarning.String(), keysAndValues...)
+}
 
-func (n noop) Error(err error, msg string, keysAndValues ...any) {}
+func (n noop) Error(err error, msg string, keysAndValues ...any) {
+	assertKvs(LevelError.String(), keysAndValues...)
+}
 
-func (n noop) Fatal(msg string, keysAndValues ...any) { os.Exit(1) }
+func (n noop) Fatal(msg string, keysAndValues ...any) {
+	assertKvs(LevelFatal.String(), keysAndValues...)
+	os.Exit(1)
+}
 
-func (n noop) FatalError(err error, msg string, keysAndValues ...any) { os.Exit(1) }
+func (n noop) FatalError(err error, msg string, keysAndValues ...any) {
+	assertKvs(LevelFatal.String()+"_ERROR", keysAndValues...)
+	os.Exit(1)
+}
 
-func (n noop) WithFields(keysAndValues ...any) Logger { return n }
+func (n noop) WithFields(keysAndValues ...any) Logger {
+	assertKvs("WithFields", keysAndValues...)
+	return n
+}

--- a/std_base.go
+++ b/std_base.go
@@ -48,9 +48,7 @@ func (s *stdBase) Skipping(level uint) Logger {
 }
 
 func (s *stdBase) WithFields(keysAndValues ...any) Logger {
-	if len(keysAndValues)%2 != 0 {
-		panic("uneven number of keys and values")
-	}
+	assertKvs("WithFields", keysAndValues...)
 
 	n := s.dup()
 	n.baseFields = slices.Grow(n.baseFields, len(keysAndValues)/2)
@@ -70,6 +68,7 @@ func (s *stdBase) Leveled(level Level) Logger {
 }
 
 func (s *stdBase) Debug(msg string, kvs ...any) {
+	assertKvs(LevelDebug.String(), kvs...)
 	if s.level != LevelDebug {
 		return
 	}
@@ -77,6 +76,7 @@ func (s *stdBase) Debug(msg string, kvs ...any) {
 }
 
 func (s *stdBase) Info(msg string, kvs ...any) {
+	assertKvs(LevelInfo.String(), kvs...)
 	if s.level > LevelInfo {
 		return
 	}
@@ -84,6 +84,7 @@ func (s *stdBase) Info(msg string, kvs ...any) {
 }
 
 func (s *stdBase) Warning(msg string, kvs ...any) {
+	assertKvs(LevelWarning.String(), kvs...)
 	if s.level > LevelWarning {
 		return
 	}
@@ -91,6 +92,7 @@ func (s *stdBase) Warning(msg string, kvs ...any) {
 }
 
 func (s *stdBase) Error(err error, msg string, kvs ...any) {
+	assertKvs(LevelError.String(), kvs...)
 	if s.level > LevelError {
 		return
 	}
@@ -101,6 +103,7 @@ func (s *stdBase) Error(err error, msg string, kvs ...any) {
 }
 
 func (s *stdBase) Fatal(msg string, kvs ...any) {
+	assertKvs(LevelFatal.String(), kvs...)
 	ev := getEventPool().prepare(LevelFatal, msg, s.baseFields, kvs, s.stackSkip)
 	ev.Backtrace = stackTrace(3)
 	s.handler(s.name, s.output, ev)
@@ -108,9 +111,16 @@ func (s *stdBase) Fatal(msg string, kvs ...any) {
 }
 
 func (s *stdBase) FatalError(err error, msg string, kvs ...any) {
+	assertKvs(LevelFatal.String()+"_ERROR", kvs...)
 	ev := getEventPool().prepare(LevelFatal, msg, s.baseFields, kvs, s.stackSkip)
 	ev.Error = err
 	ev.Backtrace = stackTrace(3)
 	s.handler(s.name, s.output, ev)
 	stdExit(1)
+}
+
+func assertKvs(method string, kvs ...any) {
+	if l := len(kvs); l > 0 && l%2 != 0 {
+		panic("uneven number of key-value pairs passed to " + method)
+	}
 }


### PR DESCRIPTION
Calls to `prepare` are currently panicking with the generic " index out of range" message, as no prior verification of key-value pairs is performed beforehand.  This pull request modifies `stdbase`  to verify the size of the provided key-value pairs before calling `prepare`. 

This change was also applied to `noop` so that such issues can be caught during tests.