### PR TITLE
feat: Introduce SetFatalBehavior

### DIFF
--- a/base.go
+++ b/base.go
@@ -27,6 +27,20 @@ func (l Level) String() string {
 	}
 }
 
+// FatalBehavior determines how Logger behaves when Logger.Fatal or
+// Logger.FatalError is called. See Logger.SetFatalBehavior
+type FatalBehavior uint8
+
+const (
+	// FatalExits makes Logger invoke os.Exit with status 1 after printing a
+	// message with a Fatal log level. This is the default mode.
+	FatalExits FatalBehavior = iota
+
+	// FatalPanics makes Logger emit a panic with the same message as provided
+	// to the logger method. This does not invoke os.Exit.
+	FatalPanics
+)
+
 type Logger interface {
 	// Named returns a new logger with its previous name followed by a dot,
 	// followed by the provided name.
@@ -45,6 +59,13 @@ type Logger interface {
 	// Skipping returns a copy of the current logger that will skip a given
 	// number of call stacks.
 	Skipping(count uint) Logger
+
+	// SetFatalBehavior defines how Logger behaves when Fatal or FatalError is
+	// called. By default, Logger uses FatalExits, which means that any call to
+	// a fatal logger level calls os.Exit with status 1. The other option,
+	// FatalPanics, panics after printing the log message to the configured
+	// output, allowing deferred functions to be executed.
+	SetFatalBehavior(behavior FatalBehavior)
 
 	Debug(msg string, keysAndValues ...any)
 	Info(msg string, keysAndValues ...any)

--- a/discard.go
+++ b/discard.go
@@ -1,43 +1,43 @@
 package stdlog
 
-import "os"
-
 type noop string
 
 const Discard noop = "noop"
 
-func (n noop) Named(name string) Logger { return n }
+func (n noop) Named(string) Logger { return n }
 
-func (n noop) SetLevel(level Level) {}
+func (n noop) SetLevel(Level) {}
 
-func (n noop) Leveled(level Level) Logger { return n }
+func (n noop) Leveled(Level) Logger { return n }
 
-func (n noop) Skipping(count uint) Logger { return n }
+func (n noop) Skipping(uint) Logger { return n }
 
-func (n noop) Debug(msg string, keysAndValues ...any) {
+func (n noop) SetFatalBehavior(FatalBehavior) {}
+
+func (n noop) Debug(_ string, keysAndValues ...any) {
 	assertKvs(LevelDebug.String(), keysAndValues...)
 }
 
-func (n noop) Info(msg string, keysAndValues ...any) {
+func (n noop) Info(_ string, keysAndValues ...any) {
 	assertKvs(LevelInfo.String(), keysAndValues...)
 }
 
-func (n noop) Warning(msg string, keysAndValues ...any) {
+func (n noop) Warning(_ string, keysAndValues ...any) {
 	assertKvs(LevelWarning.String(), keysAndValues...)
 }
 
-func (n noop) Error(err error, msg string, keysAndValues ...any) {
+func (n noop) Error(_ error, _ string, keysAndValues ...any) {
 	assertKvs(LevelError.String(), keysAndValues...)
 }
 
 func (n noop) Fatal(msg string, keysAndValues ...any) {
 	assertKvs(LevelFatal.String(), keysAndValues...)
-	os.Exit(1)
+	panic(msg)
 }
 
-func (n noop) FatalError(err error, msg string, keysAndValues ...any) {
+func (n noop) FatalError(msg error, _ string, keysAndValues ...any) {
 	assertKvs(LevelFatal.String()+"_ERROR", keysAndValues...)
-	os.Exit(1)
+	panic(msg)
 }
 
 func (n noop) WithFields(keysAndValues ...any) Logger {

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/go-stdlog/stdlog
 
 go 1.22.5
 
-require github.com/stretchr/testify v1.10.0
+require github.com/stretchr/testify v1.11.1
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/std_base.go
+++ b/std_base.go
@@ -6,22 +6,24 @@ import (
 )
 
 type stdBase struct {
-	output     io.Writer
-	name       string
-	level      Level
-	baseFields []*kv
-	handler    func(name string, out io.Writer, ev *stdLoggerEvent)
-	stackSkip  uint
+	output        io.Writer
+	name          string
+	level         Level
+	baseFields    []*kv
+	handler       func(name string, out io.Writer, ev *stdLoggerEvent)
+	stackSkip     uint
+	fatalBehavior FatalBehavior
 }
 
 func (s *stdBase) dup() *stdBase {
 	n := &stdBase{
-		output:     s.output,
-		name:       s.name,
-		level:      s.level,
-		baseFields: make([]*kv, 0, len(s.baseFields)),
-		handler:    s.handler,
-		stackSkip:  s.stackSkip,
+		output:        s.output,
+		name:          s.name,
+		level:         s.level,
+		baseFields:    make([]*kv, 0, len(s.baseFields)),
+		handler:       s.handler,
+		stackSkip:     s.stackSkip,
+		fatalBehavior: s.fatalBehavior,
 	}
 	for _, v := range s.baseFields {
 		n.baseFields = append(n.baseFields, v)
@@ -40,9 +42,9 @@ func (s *stdBase) Named(name string) Logger {
 	return n
 }
 
-func (s *stdBase) Skipping(level uint) Logger {
+func (s *stdBase) Skipping(count uint) Logger {
 	n := s.dup()
-	n.stackSkip = level
+	n.stackSkip = count
 
 	return n
 }
@@ -61,6 +63,8 @@ func (s *stdBase) WithFields(keysAndValues ...any) Logger {
 
 func (s *stdBase) SetLevel(level Level) { s.level = level }
 
+func (s *stdBase) SetFatalBehavior(behavior FatalBehavior) { s.fatalBehavior = behavior }
+
 func (s *stdBase) Leveled(level Level) Logger {
 	n := s.dup()
 	n.level = level
@@ -69,7 +73,7 @@ func (s *stdBase) Leveled(level Level) Logger {
 
 func (s *stdBase) Debug(msg string, kvs ...any) {
 	assertKvs(LevelDebug.String(), kvs...)
-	if s.level != LevelDebug {
+	if s.level > LevelDebug {
 		return
 	}
 	s.handler(s.name, s.output, getEventPool().prepare(LevelDebug, msg, s.baseFields, kvs, s.stackSkip))
@@ -107,7 +111,11 @@ func (s *stdBase) Fatal(msg string, kvs ...any) {
 	ev := getEventPool().prepare(LevelFatal, msg, s.baseFields, kvs, s.stackSkip)
 	ev.Backtrace = stackTrace(3)
 	s.handler(s.name, s.output, ev)
-	stdExit(1)
+	if s.fatalBehavior == FatalExits {
+		stdExit(1)
+	} else {
+		panic(msg)
+	}
 }
 
 func (s *stdBase) FatalError(err error, msg string, kvs ...any) {
@@ -116,7 +124,11 @@ func (s *stdBase) FatalError(err error, msg string, kvs ...any) {
 	ev.Error = err
 	ev.Backtrace = stackTrace(3)
 	s.handler(s.name, s.output, ev)
-	stdExit(1)
+	if s.fatalBehavior == FatalExits {
+		stdExit(1)
+	} else {
+		panic(msg)
+	}
 }
 
 func assertKvs(method string, kvs ...any) {


### PR DESCRIPTION
This introduces `SetFatalBehavior` and associated semantics to allow opt-out of immediate `os.Exit` after any `Fatal`-leveled logger is called. Instead, `SetFatalBehavior` allows the logger to be set to `panic` instead of `os.Exit`ing, which is relevant to some applications leveraging `defer` calls during termination.